### PR TITLE
Separating out dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ I got tired of reinventing wheels across jobs in data engineering, so I decided 
 1. `[postgresql](https://www.postgresql.org/download/)`
 2. `[poetry](https://python-poetry.org/docs/#installation)`
 
+When sharing this repo out, we found that some dependencies were crazy heavy, and it made sense to separate them so only those who really need them will have to wait for them to download. Accordingly, we've put `boto3` and `psycopg2` in as optional extra poetry dependencies, and separated the development dependencies `pytest` and `mypy` into their own extra, too.
+
+If you want them in your poetry env, you need to run `poetry install` with the extras flag, like so:
+
+```
+poetry install --extras "dev psql aws"
+```
+
+or 
+
+```
+poetry install -E psql -E aws -E dev
+```
+
+
 ## Organization
 
 ### Utilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,34 @@
 [tool.poetry]
 name = "plumbingbird"
-version = "0.1.0"
+version = "0.1.1"
 description = "Handy tools for common data engineering needs."
-authors = ["Rebecca Lovering <lovering810@gmail.com>"]
+authors = ["Rebecca Lovering <lovering810@gmail.com>", "Alicia Bargar <abargar@gmail.com>"]
 license = "GNU GPLv3"
 readme = "README.md"
 
+# Default Dependencies
 [tool.poetry.dependencies]
 python = "^3.12"
-boto3 = "^1.7.84"
 python-dotenv = "*"
-pytest = "*"
-psycopg2 = "*"
-requests = "*"
-pyyaml = "*"
+requests = "^2.31.0"
+pyyaml = "^6.0.1"
 smart_open = "*"
+
+psycopg2 = { version = "*", optional = true }
+boto3 = { version = "^1.7.84", optional = true }
+
+[tool.poetry.extras]
+psql = ["psycopg2"]
+aws = ["boto3"]
+
+# Optional Dependency Group
+# For development
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+mypy = "*"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,21 +14,17 @@ requests = "^2.31.0"
 pyyaml = "^6.0.1"
 smart_open = "*"
 
+
+pytest = { version = "*", optional = true }
+mypy = { version = "*", optional = true }
+
 psycopg2 = { version = "*", optional = true }
 boto3 = { version = "^1.7.84", optional = true }
 
 [tool.poetry.extras]
 psql = ["psycopg2"]
 aws = ["boto3"]
-
-# Optional Dependency Group
-# For development
-[tool.poetry.group.dev]
-optional = true
-
-[tool.poetry.group.dev.dependencies]
-pytest = "*"
-mypy = "*"
+dev = ["mypy","pytest"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Changes:
- updated version of package
- pinned some dep versions because so many asterisks hurt my heart 😬 
- added author
- added mypy to dev deps
- made `aws`, `psql`, and `dev` deps optional deps per @abargar 's suggestion in linked Issue

Considered, but not Done:
- using tool.poetry.group for dev deps/cloud providers/db types. Holding off for now because very few items need the accommodation and it's handled fine with what's here.